### PR TITLE
fix python >= 3.8 pymodbus import

### DIFF
--- a/LW3010EC.py
+++ b/LW3010EC.py
@@ -4,7 +4,14 @@
 
 from serial.tools.list_ports import comports
 from serial import Serial, PARITY_NONE, STOPBITS_ONE, EIGHTBITS
-from pymodbus.client.sync import ModbusSerialClient
+import pymodbus
+from pymodbus.version import version as pymodbus_version
+
+if pymodbus_version.major >= 3:
+    from pymodbus.client import ModbusSerialClient
+else:
+    from pymodbus.client.sync import ModbusSerialClient
+
 from enum import Enum
 from time import sleep
 import click


### PR DESCRIPTION
Added version detection, so a functional PyModbus dependency is imported

Pymodbus Version 2.5.3 is the final 2.x branch release (Supports python 2.7.x - 3.7).

Pymodbus Version 3.0.2 is the current release (Supports Python >= 3.8).