### PR TITLE
improve support for multiple psu connected by resolving tty symlinks

### DIFF
--- a/LW3010EC.py
+++ b/LW3010EC.py
@@ -7,6 +7,7 @@ from serial import Serial, PARITY_NONE, STOPBITS_ONE, EIGHTBITS
 from pymodbus.client import ModbusSerialClient
 from enum import Enum
 from time import sleep
+import os
 import click
 
 class PSU:
@@ -56,6 +57,8 @@ class PSU:
         else:
             # check specified port exists on host
             for port in com_ports_list:
+                if os.path.realpath(com_port) == port.device:
+                    found_com_port = os.path.realpath(com_port)
                 if com_port == port.device:
                     found_com_port = port.device
 


### PR DESCRIPTION
enale the ability to resolve symlinks to serial ports which effectively enables a user to connect to devices connect to specific physical usb serial ports

Since the CH340 tty hardware embedded in the 3010ec doesn't have unique serial numbers, conflicts occur when multiple are connected. this change provides a method to bypass these limitations.

the /dev/serial/by-path or /dev/serial/by-id file systems enable alternative methods to references serial ports

example usage
LW3010EC.py --on --com-port /dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.1.3:1.0-port0